### PR TITLE
[UI] New copy action

### DIFF
--- a/src/main/java/org/jabref/gui/MainMenu.java
+++ b/src/main/java/org/jabref/gui/MainMenu.java
@@ -181,6 +181,7 @@ public class MainMenu extends MenuBar {
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                         factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, taskExecutor, preferencesService, abbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_REPLACE_CONSTANTS, new CopyMoreAction(StandardActions.COPY_REPLACE_CONSTANTS, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                         factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(dialogService, stateManager, clipBoardManager, taskExecutor, preferencesService))),
 
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, frame::getCurrentLibraryTab, stateManager, undoManager)),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -19,6 +19,7 @@ public enum StandardActions implements Action {
     COPY_CITATION_HTML(Localization.lang("Copy citation (html)"), KeyBinding.COPY_PREVIEW),
     COPY_CITATION_TEXT(Localization.lang("Copy citation (text)")),
     COPY_CITATION_PREVIEW(Localization.lang("Copy preview"), KeyBinding.COPY_PREVIEW),
+    COPY_REPLACE_CONSTANTS(Localization.lang("Copy and replace string constants")),
     EXPORT_TO_CLIPBOARD(Localization.lang("Export to clipboard"), IconTheme.JabRefIcons.EXPORT_TO_CLIPBOARD),
     EXPORT_SELECTED_TO_CLIPBOARD(Localization.lang("Export selected entries to clipboard"), IconTheme.JabRefIcons.EXPORT_TO_CLIPBOARD),
     COPY(Localization.lang("Copy"), IconTheme.JabRefIcons.COPY, KeyBinding.COPY),

--- a/src/main/java/org/jabref/gui/edit/CopyMoreAction.java
+++ b/src/main/java/org/jabref/gui/edit/CopyMoreAction.java
@@ -72,6 +72,8 @@ public class CopyMoreAction extends SimpleCommand {
                     copyKeyAndLink();
             case COPY_DOI, COPY_DOI_URL ->
                     copyDoi();
+            case COPY_REPLACE_CONSTANTS ->
+                    copyReplaceConstants();
             default ->
                     LOGGER.info("Unknown copy command.");
         }
@@ -263,5 +265,9 @@ public class CopyMoreAction extends SimpleCommand {
             dialogService.notify(Localization.lang("Warning: %0 out of %1 entries have undefined citation key.",
                     Long.toString(entries.size() - entriesWithKey.size()), Integer.toString(entries.size())));
         }
+    }
+
+    private void copyReplaceConstants() {
+        // todo: When copying a BibEntry in the clipboard, also referenced @string constants should be put into the clipboard.
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -103,6 +103,7 @@ public class RightClickMenu {
                 factory.createMenuItem(StandardActions.COPY_CITE_KEY, new CopyMoreAction(StandardActions.COPY_CITE_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_REPLACE_CONSTANTS, new CopyMoreAction(StandardActions.COPY_REPLACE_CONSTANTS, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 factory.createMenuItem(StandardActions.COPY_DOI, new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 factory.createMenuItem(StandardActions.COPY_DOI_URL, new CopyMoreAction(StandardActions.COPY_DOI_URL, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 new SeparatorMenuItem()


### PR DESCRIPTION
This PR adds a new copy action method which can be called through the `Copy...` sub menu.  See screenshot for UI changes.

* The naming of this action is subject to change

Screenshot showing the new copy action in the right click menu. This option is also found under the main edit menu.
![Skärmbild 2024-02-28 121009](https://github.com/DD2480-Group1/jabref/assets/18265542/45c5c141-b4ef-4476-9339-2ef9455e8dc0)

closes #1