### PR TITLE
[Fix] Fix Null when copying

### DIFF
--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -171,7 +171,11 @@ public class ClipBoardManager {
         final ClipboardContent content = new ClipboardContent();
         BibEntryWriter writer = new BibEntryWriter(new FieldWriter(preferencesService.getFieldPreferences()), entryTypesManager);
         StringBuilder builder = new StringBuilder();
-        stringConstants.forEach(strConst -> builder.append(strConst.getParsedSerialization()));
+        for (BibtexString strConst : stringConstants) {
+            if (strConst.getParsedSerialization() != null) {
+                builder.append(strConst.getParsedSerialization());
+            }
+        }
         String serializedEntries = writer.serializeAll(entries, BibDatabaseMode.BIBTEX);
         builder.append(serializedEntries);
         // BibEntry is not Java serializable. Thus, we need to do the serialization manually

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.libraryproperties.constants;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -86,9 +87,12 @@ public class ConstantsPropertiesViewModel implements PropertiesTabViewModel {
 
     @Override
     public void storeSettings() {
-        databaseContext.getDatabase().setStrings(stringsListProperty.stream()
-                                                                    .map(this::fromBibtexStringViewModel)
-                                                                    .collect(Collectors.toList()));
+        List<BibtexString> strings = stringsListProperty.stream()
+                .map(this::fromBibtexStringViewModel)
+                .toList();
+        strings.forEach(string -> string.setParsedSerialization("@String{" +
+                string.getName() + " = " + string.getContent() + "}\n"));
+        databaseContext.getDatabase().setStrings(strings);
     }
 
     private BibtexString fromBibtexStringViewModel(ConstantsItemModel viewModel) {


### PR DESCRIPTION
This is a fix to #13, when copying the string constant can be `null` under the situation of:
1. Editing the string constant inside GUI and save the settings
2. Copy the entry

This fix adds:
1. A sanity check to ensure the result on the clipboard does not contain `null` serializable string value
2. Set the serialization when saving the setting via GUI.