### PR TITLE
[Paste] Paste function

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -18,6 +18,7 @@ import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.gui.fieldeditors.LinkedFileViewModel;
+import org.jabref.gui.libraryproperties.constants.ConstantsItemModel;
 import org.jabref.gui.undo.UndoableInsertEntries;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.DefaultTaskExecutor;
@@ -326,13 +327,14 @@ public class ImportHandler {
     public void importStringConstantsWithDuplicateCheck(List<BibtexString> stringConstants) {
         for(BibtexString stringConstantToAdd : stringConstants) {
             try {
-                bibDatabaseContext.getDatabase().addString(stringConstantToAdd);
+                ConstantsItemModel checker = new ConstantsItemModel(stringConstantToAdd.getName(), stringConstantToAdd.getContent());
+                if(checker.combinedValidationValidProperty().get()) {
+                    bibDatabaseContext.getDatabase().addString(stringConstantToAdd);
+                } else {
+                    dialogService.showErrorDialogAndWait(Localization.lang("Pasted string constant \"%0\" was not added because it is not a valid string constant", stringConstantToAdd.getName()));
+                }
             } catch (KeyCollisionException ex) {
-                LOGGER.debug("Collision when inserting constants");
-                // TODO: Handle collision with merge window.
-
-                // TODO: Use ConstantsItemModel(?) to validate string constants
-                // In the same way as when adding them manually in library properties
+                dialogService.showErrorDialogAndWait(Localization.lang("Pasted string constant %0 was not imported because it already exists in this library", stringConstantToAdd.getName()));
             }
         }
     }

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -117,6 +117,10 @@ public class BibtexParser implements Parser {
         }
     }
 
+    public List<BibtexString> getStringValues() {
+        return database.getStringValues().stream().toList();
+    }
+
     public Optional<BibEntry> parseSingleEntry(String bibtexString) throws ParseException {
         return parseEntries(bibtexString).stream().findFirst();
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2643,3 +2643,7 @@ Source\ URL=Source URL
 Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
+
+Pasted\ string\ constant\ "%0"\ was\ not\ added\ because\ it\ is\ not\ a\ valid\ string\ constant=Pasted string constant "%0" was not added because it is not a valid string constant
+Pasted\ string\ constant\ %0\ was\ not\ imported\ because\ it\ already\ exists\ in\ this\ library=Pasted string constant %0 was not imported because it already exists in this library
+


### PR DESCRIPTION
Reverted the from a newer jabref version to remove extra commits in PR #18

Added paste functionality.
The paste function now automatically copies any string constants in the clipboard and adds them
to the current library's database of string constants.

It performs checks to see if the copied string constants are correctly formatted and not duplicates of
already existing string constants.

As new dialog messages have been added, these have also been added to the English localization file, but localization for other languages are missing

fixes issue #9